### PR TITLE
Add types

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var inspect
 try {
   // eslint-disable-next-line no-useless-concat
   inspect = require('ut' + 'il').inspect
-} catch (error) {}
+} catch (_) {}
 
 exports = wrap(unist)
 module.exports = exports
@@ -75,7 +75,7 @@ function unist(node) {
   position(node.position)
 
   for (key in node) {
-    if (defined.indexOf(key) === -1) {
+    if (!defined.includes(key)) {
       vanilla(key, node[key])
     }
   }
@@ -96,7 +96,7 @@ function unist(node) {
 function vanilla(key, value) {
   try {
     assert.deepStrictEqual(value, JSON.parse(JSON.stringify(value)))
-  } catch (error) {
+  } catch (_) {
     assert.fail('non-specced property `' + key + '` should be JSON')
   }
 }
@@ -113,7 +113,7 @@ function view(value) {
       return JSON.stringify(value)
     }
     /* eslint-enable no-else-return */
-  } catch (error) {
+  } catch (_) {
     /* istanbul ignore next - Cyclical. */
     return String(value)
   }

--- a/package.json
+++ b/package.json
@@ -20,17 +20,20 @@
     "x-is-object": "^0.1.0"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "types/index.d.ts"
   ],
+  "types": "types/index.d.ts",
   "devDependencies": {
     "browserify": "^16.0.0",
+    "dtslint": "^1.0.2",
     "nyc": "^14.0.0",
     "prettier": "^1.0.0",
-    "remark-cli": "^6.0.0",
-    "remark-preset-wooorm": "^5.0.0",
+    "remark-cli": "^7.0.0",
+    "remark-preset-wooorm": "^6.0.0",
     "tape": "^4.0.0",
     "tinyify": "^2.0.0",
-    "xo": "^0.24.0"
+    "xo": "^0.25.0"
   },
   "scripts": {
     "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
@@ -39,7 +42,8 @@
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-types": "dtslint types",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
   },
   "prettier": {
     "tabWidth": 2,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "types": "types/index.d.ts",
   "devDependencies": {
     "browserify": "^16.0.0",
-    "dtslint": "^1.0.2",
+    "dtslint": "^2.0.0",
     "nyc": "^14.0.0",
     "prettier": "^1.0.0",
     "remark-cli": "^7.0.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ declare namespace unistUtilAssert {
   /**
    * A unist Node that is neither a Parent nor a Literal.
    */
-  interface VoidNode extends Node {
+  interface Void extends Node {
     children: never
     value: never
   }
@@ -33,7 +33,7 @@ declare const unistUtilAssert: {
   /**
    * Assert that node is a valid unist node, but neither parent nor literal.
    */
-  void(tree: unknown): asserts tree is unistUtilAssert.VoidNode
+  void(tree: unknown): asserts tree is unistUtilAssert.Void
 }
 
 export = unistUtilAssert

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,24 @@
+// TypeScript Version: 3.7
+
+import {Node, Parent, Literal} from 'unist'
+
+declare namespace unistUtilAssert {
+  interface VoidNode extends Node {
+    children: never
+    value: never
+  }
+
+  function parent(tree: unknown): asserts tree is Parent
+
+  function text(tree: unknown): asserts tree is Literal
+
+  // FIXME: void is a reserved functio name in TS
+  // find a way that void can be included in the typing without errors
+  // function void(tree: unknown): asserts tree is VoidNode
+}
+
+declare function unistUtilAssert(
+  tree: unknown
+): asserts tree is Node
+
+export = unistUtilAssert

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,22 +3,37 @@
 import {Node, Parent, Literal} from 'unist'
 
 declare namespace unistUtilAssert {
+  /**
+   * A unist Node that is neither a Parent nor a Literal.
+   */
   interface VoidNode extends Node {
     children: never
     value: never
   }
-
-  function parent(tree: unknown): asserts tree is Parent
-
-  function text(tree: unknown): asserts tree is Literal
-
-  // FIXME: void is a reserved functio name in TS
-  // find a way that void can be included in the typing without errors
-  // function void(tree: unknown): asserts tree is VoidNode
 }
 
-declare function unistUtilAssert(
-  tree: unknown
-): asserts tree is Node
+declare const unistUtilAssert: {
+  /**
+   * Assert that tree is a valid unist node.
+   * If tree is a parent, all children will be asserted as well.
+   */
+  (tree: unknown): asserts tree is Node
+
+  /**
+   * Assert that tree is a valid unist parent.
+   * All children will be asserted as well.
+   */
+  parent(tree: unknown): asserts tree is Parent
+
+  /**
+   * Assert that node is a valid unist literal.
+   */
+  text(tree: unknown): asserts tree is Literal
+
+  /**
+   * Assert that node is a valid unist node, but neither parent nor literal.
+   */
+  void(tree: unknown): asserts tree is unistUtilAssert.VoidNode
+}
 
 export = unistUtilAssert

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "unist-util-assert": ["index.d.ts"]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "semicolon": false,
+    "whitespace": false
+  }
+}

--- a/types/unist-util-assert-test.ts
+++ b/types/unist-util-assert-test.ts
@@ -1,9 +1,25 @@
-import {Node, Parent, Literal} from 'unist'
-import unified = require('unified')
-import assert = require('unist-util-assert')
+import * as assert from 'unist-util-assert'
 
 function testAssert() {
   const node = {}
   assert(node)
-  node
+  node // $ExpectType Node
+}
+
+function testParentAssert() {
+  const node = {}
+  assert.parent(node)
+  node // $ExpectType Parent
+}
+
+function testTextAssert() {
+  const node = {}
+  assert.text(node)
+  node // $ExpectType Literal
+}
+
+function testVoidAssert() {
+  const node = {}
+  assert.void(node)
+  node // $ExpectType VoidNode
 }

--- a/types/unist-util-assert-test.ts
+++ b/types/unist-util-assert-test.ts
@@ -1,0 +1,9 @@
+import {Node, Parent, Literal} from 'unist'
+import unified = require('unified')
+import assert = require('unist-util-assert')
+
+function testAssert() {
+  const node = {}
+  assert(node)
+  node
+}

--- a/types/unist-util-assert-test.ts
+++ b/types/unist-util-assert-test.ts
@@ -21,5 +21,5 @@ function testTextAssert() {
 function testVoidAssert() {
   const node = {}
   assert.void(node)
-  node // $ExpectType VoidNode
+  node // $ExpectType Void
 }


### PR DESCRIPTION
This currently has two major blockers
- [x] [TypeScript 3.7 with type assertion functions is not yet released](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-beta/)
- [x] A workaround needs to be found to name a function `void`

Once those are resolved, this will need:
- [x] TSDocs
- [x] Type tests
